### PR TITLE
Use deprecated Http::request() to maintain compatibility with 1.32

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,5 +4,7 @@
 			"Sam Wilson"
 		]
 	},
-	"diagrams-desc": "Render Graphviz, Mscgen, and PlantUML diagrams in wiki pages."
+	"diagrams-desc": "Render Graphviz, Mscgen, and PlantUML diagrams in wiki pages.",
+	"diagrams-error-no-response": "Diagrams error: no response received from remote service.",
+	"diagrams-error-returned-0": "Diagrams service error:"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -4,5 +4,7 @@
 			"Sam Wilson"
 		]
 	},
-	"diagrams-desc": "{{desc|name=Diagrams|url=https://www.mediawiki.org/wiki/Extension:Diagrams}}"
+	"diagrams-desc": "{{desc|name=Diagrams|url=https://www.mediawiki.org/wiki/Extension:Diagrams}}",
+	"diagrams-error-no-response": "Error message displayed when no response is received from the web service.",
+	"diagrams-error-returned-0": "Error message label for errors returned by the web service."
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Diagrams;
 
 use Html;
+use Http;
 use MediaWiki\MediaWikiServices;
 use Parser;
 
@@ -15,6 +16,11 @@ class Hooks {
 	public static function onParserFirstCallInit( Parser $parser ) {
 		foreach ( [ 'graphviz', 'mscgen', 'uml' ] as $tag ) {
 			$parser->setHook( $tag, function ( string $input ) use ( $tag ) {
+				// Make sure there's something to render.
+				$input = trim( $input );
+				if ( $input === '' ) {
+					return '';
+				}
 				if ( $tag === 'graphviz' ) {
 					// GraphViz.
 					return static::render( $tag, $input, 'cmapx' );
@@ -30,6 +36,15 @@ class Hooks {
 	}
 
 	/**
+	 * Get HTML for an error message.
+	 * @param string $error Error message. May contain HTML.
+	 * @return string
+	 */
+	protected static function formatError( $error ) {
+		return Html::rawElement( 'span', [ 'class' => 'ext-diagrams error' ], $error );
+	}
+
+	/**
 	 * The main rendering method, handling all types.
 	 * @param string $generator
 	 * @param string $input
@@ -37,24 +52,26 @@ class Hooks {
 	 * @return string
 	 */
 	protected static function render( $generator, $input, $type = null ) {
-		$requestFactory = MediaWikiServices::getInstance()->getHttpRequestFactory();
 		$baseUrl = MediaWikiServices::getInstance()->getMainConfig()->get( 'DiagramsServiceUrl' );
 		$url = trim( $baseUrl, '/' ) . '/render';
 		$params = [
 			'postData' => [
 				'generator' => $generator,
-				'types' => array_filter( [ 'png', $type ] ),
+				'types' => json_encode( array_filter( [ 'png', $type ] ) ),
 				'source' => $input,
 			],
 		];
-		$result = $requestFactory->request( 'POST', $url, $params, __METHOD__ );
-		$response = \GuzzleHttp\json_decode( $result );
+		$result = Http::request( 'POST', $url, $params, __METHOD__ );
+		if ( $result === false ) {
+			return static::formatError( wfMessage( 'diagrams-error-no-response' ) );
+		}
+		$response = json_decode( $result );
 		if ( isset( $response->error ) ) {
-			$error = wfMessage( 'diagrams-error-' . $response->error );
+			$error = wfMessage( 'diagrams-error-returned-' . $response->error );
 			if ( isset( $response->message ) ) {
 				$error .= Html::element( 'br' ) . $response->message;
 			}
-			return Html::rawElement( 'span', [ 'class' => 'error' ], $error );
+			return static::formatError( $error );
 		}
 		$imgAttrs = [ 'src' => $response->diagrams->png->url ];
 		if ( isset( $response->diagrams->cmapx->contents ) ) {


### PR DESCRIPTION
Also make error messages a bit clearer.