### PR TITLE
Make the service handle non-PNG formats

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,5 +8,6 @@
 	"diagrams-desc": "Render Graphviz, Mscgen, and PlantUML diagrams in wiki pages.",
 	"diagrams-error-no-response": "Diagrams error: no response received from remote service.",
 	"diagrams-error-returned-0": "Diagrams service error:",
+	"diagrams-error-bad-format": "Diagrams service error: format '$1' was not returned.",
 	"diagrams-error-generic": "Diagrams error:"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -6,7 +6,8 @@
 	},
 	"diagrams-extensionname": "{{name}}",
 	"diagrams-desc": "{{desc|name=Diagrams|url=https://www.mediawiki.org/wiki/Extension:Diagrams}}",
-	"diagrams-error-generic": "Error message label for errors that don't have a more specific message.",
 	"diagrams-error-no-response": "Error message displayed when no response is received from the web service.",
-	"diagrams-error-returned-0": "Error message label for errors returned by the web service."
+	"diagrams-error-returned-0": "Error message label for errors returned by the web service.",
+	"diagrams-error-bad-format": "Error message label for when the web service doesn't return the requested format.",
+	"diagrams-error-generic": "Error message label for errors that don't have a more specific message."
 }


### PR DESCRIPTION
Add the user-supplied format to the request to the web service,
and show an error if it's not returned for display.

Bug: GH#13