### PR TITLE
Improve file storage logic

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -10,7 +10,7 @@
 	"descriptionmsg": "diagrams-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.34.0, <= 1.39"
+		"MediaWiki": ">= 1.34.0, <= 1.40"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\Diagrams\\": "includes/"
@@ -28,7 +28,8 @@
 		"main": {
 			"class": "MediaWiki\\Extension\\Diagrams\\Hooks",
 			"services": [
-				"MainConfig"
+				"MainConfig",
+				"ShellCommandFactory"
 			]
 		}
 	},

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Diagrams;
 use Config;
 use Html;
 use MediaWiki\Hook\ParserFirstCallInitHook;
+use MediaWiki\Shell\CommandFactory;
 use Parser;
 use PPFrame;
 
@@ -13,11 +14,16 @@ class Hooks implements ParserFirstCallInitHook {
 	/** @var Config */
 	private $config;
 
+	/** @var CommandFactory */
+	private $commandFactory;
+
 	/**
 	 * @param Config $config
+	 * @param CommandFactory $commandFactory
 	 */
-	public function __construct( Config $config ) {
+	public function __construct( Config $config, CommandFactory $commandFactory ) {
 		$this->config = $config;
+		$this->commandFactory = $commandFactory;
 	}
 
 	/**
@@ -25,9 +31,7 @@ class Hooks implements ParserFirstCallInitHook {
 	 * @param Parser $parser
 	 */
 	public function onParserFirstCallInit( $parser ) {
-		$parserOptions = $parser->getOptions();
-		$isPreview = $parserOptions ? $parserOptions->getIsPreview() : false;
-		$diagrams = new Diagrams( $isPreview );
+		$diagrams = new Diagrams( $this->commandFactory );
 		$renderMethod = $this->config->get( 'DiagramsServiceUrl' )
 			? 'renderWithService'
 			: 'renderLocally';


### PR DESCRIPTION
* Use BoxedCommand for shelling out.
* Remove separate preview logic (which wasn't working anyway).
* Correctly check for existing file, and return its URL.
* Use sha1 instead of MD5 for filename hash.
* Better error display (remove outer paragraph, so it gets .error class).
* Update required core version to 1.40.