### PR TITLE
For local rendering, store all output files

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -10,7 +10,7 @@
 	"descriptionmsg": "diagrams-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.34.0, <= 1.40"
+		"MediaWiki": ">= 1.34.0, <= 1.41"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\Diagrams\\": "includes/"


### PR DESCRIPTION
Add the image map file to the repo as well, so that it can be used when viewing.

Bug: GitHub #76