### PR TITLE
Replace Deprecated `Http::request` using HttpRequestFactory

### DIFF
--- a/includes/Diagrams.php
+++ b/includes/Diagrams.php
@@ -3,7 +3,6 @@
 namespace MediaWiki\Extension\Diagrams;
 
 use Html;
-use Http;
 use LocalRepo;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Shell\CommandFactory;
@@ -189,8 +188,9 @@ class Diagrams {
 				'source' => $input,
 			] ),
 		];
-		$result = Http::request( 'POST', $url, $requestParams, __METHOD__ );
-		if ( $result === false ) {
+		$http = MediaWikiServices::getInstance()->getHttpRequestFactory();
+		$result = $http->post( $url, $requestParams, __METHOD__ );
+		if ( $result === null ) {
 			return static::formatError( wfMessage( 'diagrams-error-no-response' ) );
 		}
 		$response = json_decode( $result );


### PR DESCRIPTION
The `Http` class was deprecated in MediaWiki 1.34, and seems to have been fully removed in 1.41, breaking this extension with external rendering. I've replaced it with `HttpRequestFactory` via `MediaWikiServices::getInstance()->getHttpRequestFactory();` which I believe to be correct, but I am not very familiar with the MediaWiki PHP API so this might not be the best way to do it.