### PR TITLE
feat: add a `type` param for plantuml's <uml> tag

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -5,7 +5,7 @@
 	"author": [
 		"[https://samwilson.id.au/ Sam Wilson]"
 	],
-	"version": "0.13.1",
+	"version": "0.14.0",
 	"url": "https://www.mediawiki.org/wiki/Extension:Diagrams",
 	"descriptionmsg": "diagrams-desc",
 	"license-name": "GPL-3.0-or-later",

--- a/includes/Diagrams.php
+++ b/includes/Diagrams.php
@@ -113,7 +113,8 @@ class Diagrams {
 					$info = pathinfo( $tmpGraphSourceFile->getPath() );
 					$outputPath = $info['dirname'] . '/' . $info['filename'] . '.' . $outputFormat;
 					$tmpOutFiles[$outputType] = new TempFSFile( $outputPath );
-					$input = "@startuml\n$input\n@enduml";
+					$type = $params['type'] ?? 'uml';
+					$input = "@start$type\n$input\n@end$type";
 					$cmdArgs = [ "-t$outputFormat", '-output', dirname( $tmpOutFiles[$outputType]->getPath() ) ];
 				} else {
 					$tmpOutFiles[$outputType] = $tmpFactory->newTempFSFile( 'diagrams_out_', $outputFormat );


### PR DESCRIPTION
- enable extra diagram types in plantuml like ebnf, chen,  gantt, json,
  mindmap, regex, salt, wbs, yam… to be disambiguated