### PR TITLE
Add $wgDiagramsLocalCommands to allow custom commands

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -19,6 +19,14 @@
 		"DiagramsServiceUrl": {
 			"description": "URL of the diagram-rendering service. If not provided, graphs will be locally rendered.",
 			"value": ""
+		},
+		"DiagramsLocalCommands": {
+			"description": "Command to run for each local rendering tool.",
+			"value": {
+				"dot": "dot",
+				"mscgen": "mscgen",
+				"plantuml": "plantuml"
+			}
 		}
 	},
 	"Hooks": {

--- a/includes/Diagrams.php
+++ b/includes/Diagrams.php
@@ -2,9 +2,9 @@
 
 namespace MediaWiki\Extension\Diagrams;
 
+use Config;
 use Html;
 use LocalRepo;
-use MediaWiki\Config\Config;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Shell\CommandFactory;
 use MediaWiki\Shell\Result;

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -33,7 +33,7 @@ class Hooks implements ParserFirstCallInitHook {
 	public function onParserFirstCallInit( $parser ) {
 		$parserOptions = $parser->getOptions();
 		$isPreview = $parserOptions ? $parserOptions->getIsPreview() : false;
-		$diagrams = new Diagrams( $isPreview, $this->commandFactory );
+		$diagrams = new Diagrams( $isPreview, $this->commandFactory, $this->config );
 		$renderMethod = $this->config->get( 'DiagramsServiceUrl' )
 			? 'renderWithService'
 			: 'renderLocally';

--- a/maintenance/deleteOldDiagramsFiles.php
+++ b/maintenance/deleteOldDiagramsFiles.php
@@ -23,7 +23,7 @@ class DeleteOldDiagramsFiles extends Maintenance {
 
 	public function execute(): void {
 		$services = MediaWikiServices::getInstance();
-		$diagrams = new Diagrams( false, $services->getShellCommandFactory() );
+		$diagrams = new Diagrams( false, $services->getShellCommandFactory(), $this->getConfig() );
 		$repo = $diagrams->getDiagramsRepo();
 		$deletedCount = 0;
 		$ttl = $this->getOption( 'ttl', 30 ) * 60 * 60 * 24;


### PR DESCRIPTION
Add a new config variable `$wgDiagramsLocalCommands` that is an array of renderer commands mapped to their CLI invocations, sort of similar to `$wgSVGConverters` (but without the placeholder replacement aspect of that).

This makes it possible to override the command that gets used when rendering locally, e.g.:

```php
$wgDiagramsLocalCommands = [
	'plantuml' => '/usr/bin/java -jar /usr/local/bin/plantuml-1.2024.6.jar',
];
```

Bug: GH #16