### PR TITLE
Update MW dependency

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -10,7 +10,7 @@
 	"descriptionmsg": "diagrams-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.34.0, <= 1.43"
+		"MediaWiki": ">= 1.34.0, <= 1.43.*"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\Diagrams\\": "includes/"


### PR DESCRIPTION
This PR weakens the dependency for MediaWiki to include minor versions of MW1.43 as well. We found that the latest MediaWiki release (1.43.1) breaks when using the Diagrams extension, because 1.43.1 > 1.43.