### PR TITLE
Fix MediaWiki 1.44 Special:Version page compatibility

### DIFF
--- a/resources/foreign/foreign-resources.yaml
+++ b/resources/foreign/foreign-resources.yaml
@@ -4,3 +4,4 @@ mermaid:
   version: 9.1.1
   src: https://unpkg.com/mermaid@9.1.1/dist/mermaid.min.js
   integrity: sha384-6qzFcd+IG/OgXej451KTI/pbrex++8tdIfKsNF+gDVx1gfkmIG7z+uIIspvxAP7u
+  homepage: https://mermaid.js.org/


### PR DESCRIPTION
Add missing homepage field for mermaid library in foreign-resources.yaml. This resolves a TypeError in Special:Version page where MediaWiki tries to create external links for libraries but gets null for homepage URLs.

Fixes: TypeError: MediaWiki\Linker\LinkRenderer::makeExternalLink(): Argument #1 ($url) must be of type string, null given
