### PR TITLE
Include command name in filename hash

### DIFF
--- a/includes/Diagrams.php
+++ b/includes/Diagrams.php
@@ -89,7 +89,7 @@ class Diagrams {
 
 		// Create File objects for each of the target output formats.
 		$files = [];
-		$fileNameBase = 'Diagrams_' . md5( $input ) . '.';
+		$fileNameBase = 'Diagrams_' . md5( $commandName . $input ) . '.';
 		foreach ( $outputFormats as $outputType => $outputFormat ) {
 			$fileName = $fileNameBase . $outputFormat;
 			$file = $diagramsRepo->findFile( $fileName );


### PR DESCRIPTION
The command name might vary without the output format varying, so should be included in the filename hash.